### PR TITLE
Chore: golangci-lint fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,13 @@
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - durationcheck
     - errcheck
-    - exportloopref
     - forcetypeassert
     - gofmt
     - gosimple
@@ -19,7 +19,7 @@ linters:
     - paralleltest
     - predeclared
     - staticcheck
-    - tenv
     - unconvert
     - unparam
     - unused
+    - usetesting

--- a/datasource/timeouts/schema_test.go
+++ b/datasource/timeouts/schema_test.go
@@ -74,7 +74,7 @@ func TestBlockWithOpts(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual := timeouts.BlockWithOpts(context.Background(), test.opts)
@@ -118,7 +118,7 @@ func TestBlock(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual := timeouts.Block(context.Background())
@@ -189,7 +189,7 @@ func TestAttributesWithOpts(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual := timeouts.AttributesWithOpts(context.Background(), test.opts)
@@ -234,7 +234,7 @@ func TestAttributes(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual := timeouts.Attributes(context.Background())

--- a/datasource/timeouts/timeouts.go
+++ b/datasource/timeouts/timeouts.go
@@ -131,6 +131,7 @@ func (t Value) getTimeout(ctx context.Context, timeoutName string, defaultTimeou
 
 	// No type assertion check is required as the schema guarantees that the object attributes
 	// are types.String.
+	//nolint:forcetypeassert
 	timeout, err := time.ParseDuration(value.(types.String).ValueString())
 	if err != nil {
 		diags.Append(diag.NewErrorDiagnostic(

--- a/datasource/timeouts/timeouts_test.go
+++ b/datasource/timeouts/timeouts_test.go
@@ -56,7 +56,7 @@ func TestTimeoutsTypeValueFromTerraform(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -127,7 +127,7 @@ func TestTimeoutsTypeEqual(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -216,7 +216,7 @@ func TestTimeoutsValueRead(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/ephemeral/timeouts/schema_test.go
+++ b/ephemeral/timeouts/schema_test.go
@@ -74,7 +74,7 @@ func TestBlockWithOpts(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual := timeouts.BlockWithOpts(context.Background(), test.opts)
@@ -118,7 +118,7 @@ func TestBlock(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual := timeouts.Block(context.Background())
@@ -189,7 +189,7 @@ func TestAttributesWithOpts(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual := timeouts.AttributesWithOpts(context.Background(), test.opts)
@@ -234,7 +234,7 @@ func TestAttributes(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual := timeouts.Attributes(context.Background())

--- a/ephemeral/timeouts/timeouts.go
+++ b/ephemeral/timeouts/timeouts.go
@@ -131,6 +131,7 @@ func (t Value) getTimeout(ctx context.Context, timeoutName string, defaultTimeou
 
 	// No type assertion check is required as the schema guarantees that the object attributes
 	// are types.String.
+	//nolint:forcetypeassert
 	timeout, err := time.ParseDuration(value.(types.String).ValueString())
 	if err != nil {
 		diags.Append(diag.NewErrorDiagnostic(

--- a/ephemeral/timeouts/timeouts_test.go
+++ b/ephemeral/timeouts/timeouts_test.go
@@ -56,7 +56,7 @@ func TestTimeoutsTypeValueFromTerraform(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -127,7 +127,7 @@ func TestTimeoutsTypeEqual(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -216,7 +216,7 @@ func TestTimeoutsValueOpen(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/validators/timeduration_test.go
+++ b/internal/validators/timeduration_test.go
@@ -47,7 +47,7 @@ func TestTimeDuration(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			request := validator.StringRequest{

--- a/resource/timeouts/schema_test.go
+++ b/resource/timeouts/schema_test.go
@@ -158,7 +158,7 @@ func TestBlock(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual := timeouts.Block(context.Background(), test.opts)
@@ -379,7 +379,7 @@ func TestAttributes(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			actual := timeouts.Attributes(context.Background(), test.opts)

--- a/resource/timeouts/timeouts.go
+++ b/resource/timeouts/timeouts.go
@@ -149,6 +149,7 @@ func (t Value) getTimeout(ctx context.Context, timeoutName string, defaultTimeou
 
 	// No type assertion check is required as the schema guarantees that the object attributes
 	// are types.String.
+	//nolint:forcetypeassert
 	timeout, err := time.ParseDuration(value.(types.String).ValueString())
 	if err != nil {
 		diags.Append(diag.NewErrorDiagnostic(

--- a/resource/timeouts/timeouts_test.go
+++ b/resource/timeouts/timeouts_test.go
@@ -71,7 +71,7 @@ func TestTimeoutsTypeValueFromTerraform(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -142,7 +142,7 @@ func TestTimeoutsTypeEqual(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -231,7 +231,7 @@ func TestTimeoutsValueCreate(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -325,7 +325,7 @@ func TestTimeoutsValueRead(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -419,7 +419,7 @@ func TestTimeoutsValueUpdate(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -513,7 +513,7 @@ func TestTimeoutsValueDelete(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
- Replace `max-per-linter` with `max-issues-per-linters`
- Replace `exportloopref` linter with `copyloopvar`
- Replace `tenv` linter with `usetesting`